### PR TITLE
Implement PIOC GPIO fallback for old hardware support

### DIFF
--- a/DAP/SW_DP.c
+++ b/DAP/SW_DP.c
@@ -138,12 +138,14 @@ void SWD_Sequence(uint32_t info, const uint8_t *swdo, uint8_t *swdi)
 }
 #endif
 
-#if (!USE_PIOC_ACC)
 #if (DAP_SWD != 0)
 // SWD Transfer I/O Fast
 //   request: A[3:2] RnW APnDP
 //   data:    DATA[31:0]
 //   return:  ACK[2:0]
+#if (!USE_PIOC_ACC)
+__attribute__((section(".highcode")))
+#endif
  static uint8_t SWD_TransferFast(
 		uint32_t request, uint32_t *data)
 {
@@ -385,6 +387,9 @@ void SWD_Sequence(uint32_t info, const uint8_t *swdo, uint8_t *swdi)
 //   request: A[3:2] RnW APnDP
 //   data:    DATA[31:0]
 //   return:  ACK[2:0]
+#if (!USE_PIOC_ACC)
+__attribute__((section(".highcode")))
+#endif
  static uint8_t SWD_TransferSlow(
 		uint32_t request, uint32_t *data)
 {
@@ -626,8 +631,13 @@ void SWD_Sequence(uint32_t info, const uint8_t *swdo, uint8_t *swdi)
 //   request: A[3:2] RnW APnDP
 //   data:    DATA[31:0]
 //   return:  ACK[2:0]
- uint8_t SWD_Transfer(uint32_t request,
-		uint32_t *data)
+#if (!USE_PIOC_ACC)
+__attribute__((section(".highcode")))
+ uint8_t SWD_Transfer(uint32_t request, uint32_t *data)
+#else
+__attribute__((noinline))
+ uint8_t SWD_Transfer_GPIO(uint32_t request, uint32_t *data)
+#endif
 {
 	if (DAP_Data.fast_clock)
 	{
@@ -638,6 +648,5 @@ void SWD_Sequence(uint32_t info, const uint8_t *swdo, uint8_t *swdi)
 		return SWD_TransferSlow(request, data);
 	}
 }
-#endif
 
 #endif  /* (DAP_SWD != 0) */

--- a/Middleware/usbqueue.h
+++ b/Middleware/usbqueue.h
@@ -25,7 +25,11 @@
 /*
  * UQ_QUEUELEN: Defines the queue length
  */
+#if (USE_PIOC_ACC)
 #define UQ_QUEUELEN 20
+#else
+#define UQ_QUEUELEN 12
+#endif
 
 /*
  * UQ_PACKLEN_MAX: Defines the max length of USB packet received

--- a/PIOC/dap_pioc.c
+++ b/PIOC/dap_pioc.c
@@ -66,6 +66,7 @@ void PIOC_DAP_PutData (uint8_t *data, uint16_t len) {
 #include "DAP.h"
 extern volatile uint8_t DAP_PIOC_ClockDelay[2];
 extern volatile uint8_t DAP_PIOC_FastClock;
+extern volatile uint8_t DAP_PIOC_FallbackFlag;
 
 void PIOC_DAP_LoadCfg (void) {
     // SFR_DATA_REG0 is used for DAP turnaround cycle
@@ -108,12 +109,17 @@ int PIOC_DAP_RunAndWait(void) {
     return flagDeadlock;
 }
 
+extern uint8_t SWD_Transfer_GPIO(uint32_t request, uint32_t *data);
+
 // SWD Transfer I/O
 //   request: A[3:2] RnW APnDP
 //   data:    DATA[31:0]
 //   return:  ACK[2:0]
 __attribute__((section(".highcode")))
 uint8_t SWD_Transfer (uint32_t request, uint32_t *data) {
+    if(DAP_PIOC_FallbackFlag){
+        return SWD_Transfer_GPIO(request, data);
+    }
     uint32_t tmp;
     // Enable PIOC GPIOs
     tmp = GPIOC->CFGXR;

--- a/User/main.c
+++ b/User/main.c
@@ -53,6 +53,8 @@ static void ConvertUint32ToUnicode16Str (uint32_t num, unsigned char *str) {
     }
 }
 
+volatile uint8_t DAP_PIOC_FallbackFlag = 0;
+
 __attribute__ ((noreturn)) int main (void) {
     NVIC_PriorityGroupConfig (NVIC_PriorityGroup_0);
     SystemCoreClockUpdate();
@@ -110,6 +112,7 @@ __attribute__ ((noreturn)) int main (void) {
     if (!flagPIOCConnected) {
         GPIOC->BCR = GPIO_Pin_3;
         GPIOA->BSHR = GPIO_Pin_0 | GPIO_Pin_1;
+        DAP_PIOC_FallbackFlag = 1;
         Delay_Ms (2000);
     }
     GPIO_InitStructure.GPIO_Pin = GPIO_Pin_5 | GPIO_Pin_7;


### PR DESCRIPTION
*Generated by copilot*  

This pull request introduces changes to support a fallback mechanism for SWD transfers when PIOC is not available, as well as configuration improvements for queue lengths and memory section placement. The main updates ensure that the system can switch to a GPIO-based SWD transfer implementation if PIOC is unavailable, improving robustness and flexibility.

**Fallback mechanism for SWD transfers:**

* Added a global variable `DAP_PIOC_FallbackFlag` to indicate when to use the fallback GPIO-based SWD transfer (`SWD_Transfer_GPIO`). The flag is set if PIOC is not connected during startup (`User/main.c`, `PIOC/dap_pioc.c`). [[1]](diffhunk://#diff-75604d824a08a0d8e1da8a5f27356cfa28d1d3e3f3ad9dd5d45fa1b6aba15e47R56-R57) [[2]](diffhunk://#diff-75604d824a08a0d8e1da8a5f27356cfa28d1d3e3f3ad9dd5d45fa1b6aba15e47R115) [[3]](diffhunk://#diff-020bcf4587927f3026a05af5302d6cd4ebabaf6ac79dce880232fd321eef8e49R69)
* Modified `SWD_Transfer` in `PIOC/dap_pioc.c` to check `DAP_PIOC_FallbackFlag` and delegate to `SWD_Transfer_GPIO` if set, ensuring seamless fallback.
* Declared and implemented `SWD_Transfer_GPIO` for the fallback path, and adjusted function attributes and naming for both PIOC and non-PIOC implementations in `DAP/SW_DP.c`. [[1]](diffhunk://#diff-ae2843fde65cc0ca9cee1b6057c61ad69657a7b1ce8d6492251264831baf8ca2L629-R640) [[2]](diffhunk://#diff-020bcf4587927f3026a05af5302d6cd4ebabaf6ac79dce880232fd321eef8e49R112-R122)

**Configuration and performance improvements:**

* Updated the queue length in `usbqueue.h` to use a larger size when PIOC acceleration is enabled (`UQ_QUEUELEN` is now 20 if `USE_PIOC_ACC`, otherwise 12).
* Placed critical SWD transfer functions in the `.highcode` section for improved performance when not using PIOC acceleration, and marked the GPIO fallback transfer as `noinline`. [[1]](diffhunk://#diff-ae2843fde65cc0ca9cee1b6057c61ad69657a7b1ce8d6492251264831baf8ca2L141-R148) [[2]](diffhunk://#diff-ae2843fde65cc0ca9cee1b6057c61ad69657a7b1ce8d6492251264831baf8ca2R390-R392) [[3]](diffhunk://#diff-ae2843fde65cc0ca9cee1b6057c61ad69657a7b1ce8d6492251264831baf8ca2L629-R640)

These changes collectively enhance the system's reliability by providing a fallback path for SWD transfers and optimizing code placement and configuration for different hardware scenarios.